### PR TITLE
Hotfix. Users logging to specific user account with any random email

### DIFF
--- a/api/services/authentication.js
+++ b/api/services/authentication.js
@@ -6,7 +6,7 @@ const userService = require('./user');
 const Error = require('./../error');
 
 module.exports.login = (email, password) => new Promise((resolve, reject) => {
-  return userService.getUser({ 'profile.email': email })
+  return userService.getUser({ conditions: { 'profile.email': email } })
     .then((user) => {
       if (!user) {
         const error = Error.generateError(401, 'Bad email', { id: 'BAD_EMAIL' });


### PR DESCRIPTION
Solved an issue that made people be able to log in to the first user's account found by db.collection.findOne() with any random string as email, as long as the password for that specific account was correct.

I.e:
Account -> email: example@example.com | password: 1234.
Input -> example@example.com | 1234 -> Access granted to example@example.com
Input -> random@random.com | 1234 -> Access granted to **example@example.com** too